### PR TITLE
Use Hackage friendly settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -62,3 +62,6 @@ packages:
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+# https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds
+pvp-bounds: both


### PR DESCRIPTION
This helps ensure that Stack includes more accurate version bounds which are essential for for the Hackage/Cabal ecosystem to provide a good user experience to consumers of your package.

See also https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds for more details